### PR TITLE
Fix fadeout

### DIFF
--- a/node.lua
+++ b/node.lua
@@ -41,7 +41,7 @@ function node.render()
     for idx, dep in ipairs(departures) do
         if dep.date > now  - fadeout then
             if now > dep.date then
-                y = y - 120 / fadeout * (now - dep.date)
+                y = y - 130 / fadeout * (now - dep.date)
             end
         end
     end


### PR DESCRIPTION
In lines 96 and 98, y offset is incremented by 60+70 (130 in total). Fadeout was calculated using 120px, so display would jump by 10px on end of fadeout.